### PR TITLE
feat(animation): implement settling bounce for hero title

### DIFF
--- a/index.css
+++ b/index.css
@@ -645,3 +645,5 @@ body {
 .content {
   flex: 1; /* This will make sure the content area takes up the remaining space */
 }
+
+

--- a/index.html
+++ b/index.html
@@ -220,6 +220,14 @@
       html {
         scroll-behavior: smooth;
       }
+      @keyframes bounce-settle {
+        0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+        40% { transform: translateY(-30px); }
+        60% { transform: translateY(-15px); }
+      }
+      .animate-bounce-settle {
+        animation: bounce-settle 2s ease-in-out 1;
+      }
     </style>
   </head>
   <body class="bg-dark text-white font-sans pt-24">
@@ -281,7 +289,7 @@
       class="min-h-screen flex flex-col justify-center items-center pt-32 text-center"
     >
       <h1
-        class="text-4xl md:text-6xl font-extrabold text-primary drop-shadow-2xl animate-bounce"
+        class="text-4xl md:text-6xl font-extrabold text-primary drop-shadow-2xl animate-bounce-settle"
       >
         100 DAYS OF 100 WEB PROJECTS
       </h1>


### PR DESCRIPTION
<img width="1367" height="310" alt="image" src="https://github.com/user-attachments/assets/035e32d0-1968-4469-8aa3-976b9fbac353" />

This PR updates the hero title's entrance animation. Previously, the title was in an infinite bounce loop. This has been changed so the animation runs only once when the user loads the site, concluding with a smooth, settling stop.
This was achieved by replacing the default animate-bounce class with a custom .animate-bounce-settle utility, creating a more polished and less distracting user experience.