### PR TITLE
added mode selection and 2-player mode support

### DIFF
--- a/public/day10/index.html
+++ b/public/day10/index.html
@@ -7,27 +7,50 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="container">
-    <h1>Rock Paper Scissors ✊✋✌️</h1>
+ <div class="container">
 
-    <div class="scoreboard">
-      <p>Player: <span id="player-score">0</span></p>
-      <p>Computer: <span id="computer-score">0</span></p>
+    <div id="mode-selection" class="screen active">
+      <h1>Rock Paper Scissors ✊✋✌️</h1>
+      <h2>Choose Game Mode</h2>
+      <div class="mode-buttons">
+        <button class="mode-btn" data-mode="vs-computer">🖥️ Play vs Computer</button>
+        <button class="mode-btn" data-mode="two-player">👥 2-Player Mode</button>
+      </div>
     </div>
 
-    <div class="choices">
-      <button class="choice" data-choice="rock">✊ Rock</button>
-      <button class="choice" data-choice="paper">✋ Paper</button>
-      <button class="choice" data-choice="scissors">✌️ Scissors</button>
-    </div>
+    <div id="game-screen" class="screen">
+      <div class="header">
+        <button id="back-btn" class="back-button">← Back to Home</button>
+        <h1>Rock Paper Scissors ✊✋✌️</h1>
+      </div>
 
-    <div class="result">
-      <h2 id="winner">Make your move!</h2>
-      <p id="player-choice">You: -</p>
-      <p id="computer-choice">CPU: -</p>
+      <div class="scoreboard">
+        <p><span id="player1-label">Player 1</span>: <span id="player1-score">0</span></p>
+        <p><span id="player2-label">Computer</span>: <span id="player2-score">0</span></p>
+      </div>
+
+      <div id="turn-indicator" class="turn-indicator hidden">
+        <h3 id="current-player">Player 1's Turn</h3>
+      </div>
+
+      <div class="choices">
+        <button class="choice" data-choice="rock">✊ Rock</button>
+        <button class="choice" data-choice="paper">✋ Paper</button>
+        <button class="choice" data-choice="scissors">✌️ Scissors</button>
+      </div>
+
+      <div class="result">
+        <h2 id="winner">Make your move!</h2>
+        <p id="player1-choice">Player 1: -</p>
+        <p id="player2-choice">Player 2: -</p>
+        <p id="win-note" class="small-note hidden">⚠️ First player to reach 10 points wins the game.</p>
+      </div>
+
+      <div id="continue-section" class="continue-section hidden">
+        <button id="continue-btn" class="continue-btn">Continue to Next Round</button>
+      </div>
     </div>
   </div>
-
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/day10/script.js
+++ b/public/day10/script.js
@@ -1,56 +1,261 @@
 const choices = ["rock", "paper", "scissors"];
-const buttons = document.querySelectorAll(".choice");
-const playerScoreEl = document.getElementById("player-score");
-const computerScoreEl = document.getElementById("computer-score");
+let gameMode = null;
+let currentPlayer = 1;
+let player1Score = 0;
+let player2Score = 0;
+let player1Choice = null;
+let player2Choice = null;
+let waitingForPlayer2 = false;
+
+const modeSelectionScreen = document.getElementById("mode-selection");
+const gameScreen = document.getElementById("game-screen");
+const modeButtons = document.querySelectorAll(".mode-btn");
+const backBtn = document.getElementById("back-btn");
+const choiceButtons = document.querySelectorAll(".choice");
+const player1ScoreEl = document.getElementById("player1-score");
+const player2ScoreEl = document.getElementById("player2-score");
+const player1LabelEl = document.getElementById("player1-label");
+const player2LabelEl = document.getElementById("player2-label");
 const winnerEl = document.getElementById("winner");
-const playerChoiceEl = document.getElementById("player-choice");
-const computerChoiceEl = document.getElementById("computer-choice");
+const player1ChoiceEl = document.getElementById("player1-choice");
+const player2ChoiceEl = document.getElementById("player2-choice");
+const turnIndicator = document.getElementById("turn-indicator");
+const currentPlayerEl = document.getElementById("current-player");
+const continueSection = document.getElementById("continue-section");
+const continueBtn = document.getElementById("continue-btn");
 
-let playerScore = 0;
-let computerScore = 0;
-
-buttons.forEach(button => {
+modeButtons.forEach(button => {
   button.addEventListener("click", () => {
-    const playerChoice = button.dataset.choice;
-    const computerChoice = getComputerChoice();
-    const winner = getWinner(playerChoice, computerChoice);
-    updateUI(playerChoice, computerChoice, winner);
+    gameMode = button.dataset.mode;
+    startGame();
   });
 });
+
+backBtn.addEventListener("click", () => {
+  goBackToModeSelection();
+});
+
+choiceButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    const choice = button.dataset.choice;
+    handlePlayerChoice(choice);
+  });
+});
+
+continueBtn.addEventListener("click", () => {
+  if (player1Score >= 10 || player2Score >= 10) {
+    goBackToModeSelection();
+    continueBtn.textContent = "Continue to Next Round";
+    continueBtn.onclick = () => resetForNextRound();
+  } else {
+    resetForNextRound();
+  }
+})
+function startGame() {
+  modeSelectionScreen.classList.remove("active");
+  gameScreen.classList.add("active");
+
+  player1Score = 0;
+  player2Score = 0;
+  currentPlayer = 1;
+  player1Choice = null;
+  player2Choice = null;
+  waitingForPlayer2 = false;
+
+  if (gameMode === "vs-computer") {
+    player1LabelEl.textContent = "Player";
+    player2LabelEl.textContent = "Computer";
+    turnIndicator.classList.add("hidden");
+    continueSection.classList.add("hidden");
+    document.getElementById("win-note").classList.add("hidden"); // hide note
+  } else {
+    player1LabelEl.textContent = "Player 1";
+    player2LabelEl.textContent = "Player 2";
+    turnIndicator.classList.remove("hidden");
+    currentPlayerEl.textContent = "Player 1's Turn";
+    document.getElementById("win-note").classList.remove("hidden"); // show note
+  }
+
+  updateScoreboard();
+  resetChoiceDisplay();
+  winnerEl.textContent = "Make your move!";
+  enableChoiceButtons();
+}
+
+function goBackToModeSelection() {
+  gameScreen.classList.remove("active");
+  modeSelectionScreen.classList.add("active");
+  gameMode = null;
+}
+
+function handlePlayerChoice(choice) {
+  if (gameMode === "vs-computer") {
+    handleVsComputerChoice(choice);
+  } else {
+    handleTwoPlayerChoice(choice);
+  }
+}
+
+function handleVsComputerChoice(playerChoice) {
+  const computerChoice = getComputerChoice();
+  const winner = getWinner(playerChoice, computerChoice);
+  
+  updateScores(winner);
+  updateChoiceDisplay(playerChoice, computerChoice);
+  updateWinnerDisplay(winner);
+  updateScoreboard();
+}
+
+function handleTwoPlayerChoice(choice) {
+  if (currentPlayer === 1) {
+    player1Choice = choice;
+    currentPlayer = 2;
+    currentPlayerEl.textContent = "Player 2's Turn";
+    player1ChoiceEl.textContent = "Player 1: ✓ Choice Made";
+    winnerEl.textContent = "Player 2, make your move!";
+  } else {
+    player2Choice = choice;
+    const winner = getWinner(player1Choice, player2Choice);
+
+    updateScores(winner);
+    updateChoiceDisplay(player1Choice, player2Choice);
+    updateWinnerDisplay(winner);
+    updateScoreboard();
+
+    turnIndicator.classList.add("hidden");
+    disableChoiceButtons();
+
+    if (player1Score >= 10 || player2Score >= 10) {
+      endGame();
+    } else {
+      continueSection.classList.remove("hidden");
+    }
+  }
+}
+
+function endGame() {
+  disableChoiceButtons();
+  turnIndicator.classList.add("hidden");
+
+  let message;
+  if (player1Score >= 10) {
+    message = "🎉 Player 1 wins the game! 🏆";
+  } else {
+    message = "🎉 Player 2 wins the game! 🏆";
+  }
+
+  winnerEl.textContent = message;
+
+  continueSection.classList.remove("hidden");
+  continueBtn.textContent = "🔁 Play Again";
+
+  continueBtn.onclick = () => {
+    goBackToModeSelection();
+    resetGameState();
+    continueBtn.textContent = "Continue to Next Round";
+    continueBtn.onclick = () => resetForNextRound();
+  };
+}
+
+function resetGameState() {
+  player1Score = 0;
+  player2Score = 0;
+  currentPlayer = 1;
+  player1Choice = null;
+  player2Choice = null;
+
+  updateScoreboard();
+  resetChoiceDisplay();
+  winnerEl.textContent = "Make your move!";
+  enableChoiceButtons();
+  continueSection.classList.add("hidden");
+  turnIndicator.classList.add("hidden");
+}
+
+function resetForNextRound() {
+  currentPlayer = 1;
+  player1Choice = null;
+  player2Choice = null;
+  
+  currentPlayerEl.textContent = "Player 1's Turn";
+  turnIndicator.classList.remove("hidden");
+  continueSection.classList.add("hidden");
+  
+  resetChoiceDisplay();
+  winnerEl.textContent = "Make your move!";
+  enableChoiceButtons();
+}
 
 function getComputerChoice() {
   const randomIndex = Math.floor(Math.random() * choices.length);
   return choices[randomIndex];
 }
 
-function getWinner(player, computer) {
-  if (player === computer) return "draw";
+function getWinner(choice1, choice2) {
+  if (choice1 === choice2) return "draw";
+  
   if (
-    (player === "rock" && computer === "scissors") ||
-    (player === "paper" && computer === "rock") ||
-    (player === "scissors" && computer === "paper")
+    (choice1 === "rock" && choice2 === "scissors") ||
+    (choice1 === "paper" && choice2 === "rock") ||
+    (choice1 === "scissors" && choice2 === "paper")
   ) {
-    playerScore++;
-    return "player";
+    return "player1";
   } else {
-    computerScore++;
-    return "computer";
+    return "player2";
   }
 }
 
-function updateUI(player, computer, winner) {
-  playerScoreEl.textContent = playerScore;
-  computerScoreEl.textContent = computerScore;
-  playerChoiceEl.textContent = `You: ${capitalize(player)}`;
-  computerChoiceEl.textContent = `CPU: ${capitalize(computer)}`;
+function updateScores(winner) {
+  if (winner === "player1") {
+    player1Score++;
+  } else if (winner === "player2") {
+    player2Score++;
+  }
+}
 
+function updateScoreboard() {
+  player1ScoreEl.textContent = player1Score;
+  player2ScoreEl.textContent = player2Score;
+}
+
+function updateChoiceDisplay(choice1, choice2) {
+  const player1Label = gameMode === "vs-computer" ? "You" : "Player 1";
+  const player2Label = gameMode === "vs-computer" ? "CPU" : "Player 2";
+  
+  player1ChoiceEl.textContent = `${player1Label}: ${capitalize(choice1)}`;
+  player2ChoiceEl.textContent = `${player2Label}: ${capitalize(choice2)}`;
+}
+
+function resetChoiceDisplay() {
+  const player1Label = gameMode === "vs-computer" ? "You" : "Player 1";
+  const player2Label = gameMode === "vs-computer" ? "CPU" : "Player 2";
+  
+  player1ChoiceEl.textContent = `${player1Label}: -`;
+  player2ChoiceEl.textContent = `${player2Label}: -`;
+}
+
+function updateWinnerDisplay(winner) {
   if (winner === "draw") {
     winnerEl.textContent = "It's a draw!";
-  } else if (winner === "player") {
-    winnerEl.textContent = "You win! 🎉";
+  } else if (winner === "player1") {
+    const winnerText = gameMode === "vs-computer" ? "You win! 🎉" : "Player 1 wins! 🎉";
+    winnerEl.textContent = winnerText;
   } else {
-    winnerEl.textContent = "Computer wins! 🤖";
+    const winnerText = gameMode === "vs-computer" ? "Computer wins! 🤖" : "Player 2 wins! 🎉";
+    winnerEl.textContent = winnerText;
   }
+}
+
+function enableChoiceButtons() {
+  choiceButtons.forEach(button => {
+    button.disabled = false;
+  });
+}
+
+function disableChoiceButtons() {
+  choiceButtons.forEach(button => {
+    button.disabled = true;
+  });
 }
 
 function capitalize(str) {

--- a/public/day10/style.css
+++ b/public/day10/style.css
@@ -11,20 +11,85 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  min-height: 100vh;
   text-align: center;
+  padding: 20px;
 }
 
 .container {
-  max-width: 400px;
-  padding: 20px;
+  max-width: 500px;
+  padding: 30px;
   background: #1c1f26;
   border-radius: 12px;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
 }
 
+.screen {
+  display: none;
+}
+
+.screen.active {
+  display: block;
+  margin-top: 8vh;
+}
+
 h1 {
   margin-bottom: 20px;
+  font-size: 2rem;
+}
+
+h2 {
+  margin-bottom: 30px;
+  color: #61dafb;
+  font-size: 1.5rem;
+}
+
+.mode-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.mode-btn {
+  padding: 20px;
+  font-size: 18px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.mode-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+}
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  margin-bottom: 20px;
+  gap: 10px;
+}
+
+.back-button {
+  bottom: 80px;
+  padding: 8px 16px;
+  background: #f44336;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: 0.3s ease;
+}
+
+.back-button:hover {
+  background: #d32f2f;
 }
 
 .scoreboard {
@@ -32,6 +97,22 @@ h1 {
   justify-content: space-around;
   margin-bottom: 20px;
   font-size: 18px;
+  background: #2a2d35;
+  padding: 15px;
+  border-radius: 8px;
+}
+
+.turn-indicator {
+  margin-bottom: 20px;
+  padding: 10px;
+  background: #61dafb;
+  color: #282c34;
+  border-radius: 8px;
+  font-weight: bold;
+}
+
+.turn-indicator.hidden {
+  display: none;
 }
 
 .choices {
@@ -42,7 +123,7 @@ h1 {
 }
 
 .choice {
-  padding: 12px 16px;
+  padding: 15px 20px;
   font-size: 16px;
   background: #4caf50;
   color: white;
@@ -50,14 +131,73 @@ h1 {
   border-radius: 8px;
   cursor: pointer;
   flex: 1;
-  transition: 0.3s ease;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .choice:hover {
   background: #45a049;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
+.choice:disabled {
+  background: #666;
+  cursor: not-allowed;
+  transform: none;
+}
+.small-note {
+  font-size: 12px;
+  color: #777;
+  margin-top: 8px;
+}
 .result {
   font-size: 16px;
   line-height: 1.6;
+  background: #2a2d35;
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.continue-section {
+  margin-top: 20px;
+}
+
+.continue-section.hidden {
+  display: none;
+}
+
+.continue-btn {
+  padding: 12px 24px;
+  font-size: 16px;
+  background: #ff9800;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: 0.3s ease;
+}
+
+.continue-btn:hover {
+  background: #f57c00;
+}
+
+@media (max-width: 480px) {
+  .container {
+    max-width: 100%;
+    padding: 20px;
+  }
+  
+  .choices {
+    flex-direction: column;
+  }
+  
+  .choice {
+    margin-bottom: 10px;
+  }
+  
+  h1 {
+    font-size: 1.5rem;
+  }
 }


### PR DESCRIPTION
This PR introduces a Mode Selection screen to the Rock-Paper-Scissors game, allowing users to select between:

🔘 Play vs Computer (existing logic)

👥 2-Player Mode (newly implemented)

The 2-Player mode adds a more interactive and social aspect to the game, where two users can play turn-by-turn on the same screen.

**✨ Features Added**
🚀 Mode Selection UI: A new start screen allows users to pick their preferred gameplay mode.

👥 2-Player Mode:

Players take alternate turns selecting their moves.

Dynamic turn indicators and player-specific labels.

Choice display updated after both players have made their move.

Scores are tracked until one player reaches 10 points.

🔁 Back to Home button to restart the game and reselect mode.

🧠 Game logic handles both PvC and PvP independently and cleanly.

🎯 End-game detection and replay functionality.


📌 Related Issue
Closes: #444 