### PR TITLE
[FIX]: #550 Poor Contrast in Contributor Badge (Light Mode)

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -613,7 +613,7 @@
                         <img src="${user.avatar_url}" alt="${user.login}"
                              class="w-24 h-24 rounded-full mx-auto border-4 border-primary/30 shadow-lg object-cover"
                              loading="lazy"/>
-                        <div class="absolute -bottom-2 -right-2 bg-gradient-to-r from-primary to-secondary text-white rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold">
+                        <div class="absolute -bottom-2 -right-2 bg-gradient-to-r from-primary to-secondary !text-white rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold">
                             ${user.contributions}
                         </div>
                     </div>


### PR DESCRIPTION
# Fix: Improve Contrast in Contributor Badge (Light Mode)

**Related Issue:** [#550](https://github.com/rutikakengal/100DAYS_OF_100WEBPROJECTS/issues/550)

## 📝 Summary
This PR addresses the poor text contrast inside contributor badges in light mode. Previously, the badge background was dark (e.g., blue/green) while the text inside was also dark, making it hard to read.  

## ✅ Changes Made
- Applied Tailwind’s `!text-white` to enforce white text inside the contribution badge.  
- Ensured that contribution counts (`${user.contributions}`) render with high contrast regardless of background gradient.  
- Verified UI in both light and dark modes for accessibility compliance.  

## 🎯 Result
Contributor badge text now appears **clearly visible in light mode** with proper contrast against the dark background.  

## 📸 Before & After
- **Before:** Dark text on dark background → unreadable  
- **After:** White text on dark background → easily readable  
<img width="1440" height="876" alt="Screenshot 2025-08-17 at 1 54 49 PM" src="https://github.com/user-attachments/assets/62c0acd4-f37a-426e-9e28-db94f39dc995" />
