### PR TITLE
solves #710: Option text now visible in Dark Mode

### DIFF
--- a/public/Day 36/index.css
+++ b/public/Day 36/index.css
@@ -579,6 +579,10 @@ body::before {
     backdrop-filter: blur(10px);
 }
 
+.dark-mode .option-btn {
+    color: #fff;
+}
+
 .option-btn:hover {
     transform: translateY(-2px);
     box-shadow: var(--shadow-md);
@@ -629,6 +633,10 @@ body::before {
     font-size: 1rem;
     font-weight: 500;
     color: inherit;
+}
+
+.dark-mode .option-text {
+    color: #fff;
 }
 
 .option-glow {


### PR DESCRIPTION
This PR fixes the issue where switching to dark mode during an active quiz left the option text color black, making it difficult for users to read against the dark background.

Changes Made:
- Updated option text styling to dynamically switch to white/light color when dark mode is active.
- Ensured smooth theme switching so text remains consistently visible in both themes.

Enhancements:
✅ Improved accessibility and readability
✅ Enhanced user experience while taking quizzes
✅ More polished UI with proper dark mode support

Closes: #710 
