### PR TITLE
fix: redirect footer "Browse Projects" and "About Challenge" links to main page sections from contributors page

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -593,7 +593,22 @@
             </div>
         </div>
     </footer>
+<script>
+    // Contributors page footer links
+const browseProjectsLink = document.querySelector('a[href="#projects"]');
+const aboutChallengeLink = document.querySelector('a[href="#about"]');
 
+// Redirect to index.html with section hash
+browseProjectsLink.addEventListener("click", (e) => {
+  e.preventDefault();
+  window.location.href = "index.html#projects";
+});
+
+aboutChallengeLink.addEventListener("click", (e) => {
+  e.preventDefault();
+  window.location.href = "index.html#about";
+});
+</script>
     <button id="scrollBtn" onclick="scrollToTop()"
         class="fixed bottom-8 right-8 bg-gradient-to-r from-primary to-secondary text-white p-4 rounded-full shadow-2xl z-[60] btn-modern hidden hover:scale-110 transition-all duration-300">
         <i class="fas fa-arrow-up text-xl"></i>


### PR DESCRIPTION
This PR addresses issue #729 

### Description
This PR fixes the footer links on the contributors page that were previously not functional:

- Clicking **Browse Projects** now redirects to the main page and scrolls to the Projects section.
- Clicking **About Challenge** now redirects to the main page and scrolls to the About section.

This improves navigation and overall user experience.

### Before / After

**Before:**  
- On the contributors page, the **Browse Projects** and **About Challenge** footer links didn’t work.  
- Clicking them did nothing, confusing users.

**After:**  
- Footer links now redirect to the main page (`index.html`) and automatically scroll to the corresponding sections:  
  - **Browse Projects** → Projects section  
  - **About Challenge** → About section  
- Works on all devices (desktop & mobile), improving navigation and UX.

### Testing Steps
1. Open `contributors.html` page in a browser.
2. Click the **Browse Projects** link in the footer → should redirect to `index.html` and scroll to the Projects section.
3. Click the **About Challenge** link in the footer → should redirect to `index.html` and scroll to the About section.
